### PR TITLE
기자재에 분류 타입 추가

### DIFF
--- a/src/main/java/Ampersand/GKR/domain/equipment/entity/Equipment.java
+++ b/src/main/java/Ampersand/GKR/domain/equipment/entity/Equipment.java
@@ -1,5 +1,6 @@
 package Ampersand.GKR.domain.equipment.entity;
 
+import Ampersand.GKR.domain.equipment.enums.EquipmentType;
 import Ampersand.GKR.domain.equipment.enums.RentStatus;
 import Ampersand.GKR.domain.equipment.presentation.dto.request.EditEquipmentRequest;
 import lombok.*;
@@ -32,9 +33,13 @@ public class Equipment {
     @Enumerated(EnumType.STRING)
     private RentStatus rentStatus;
 
+    @Enumerated(EnumType.STRING)
+    private EquipmentType equipmentType;
+
     public void update(EditEquipmentRequest equipmentRequest, String fileUrl) {
         this.name = equipmentRequest.getName();
         this.description = equipmentRequest.getDescription();
         this.imageUrl = fileUrl;
+        this.equipmentType = equipmentRequest.getEquipmentType();
     }
 }

--- a/src/main/java/Ampersand/GKR/domain/equipment/enums/EquipmentType.java
+++ b/src/main/java/Ampersand/GKR/domain/equipment/enums/EquipmentType.java
@@ -1,0 +1,11 @@
+package Ampersand.GKR.domain.equipment.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum EquipmentType {
+
+    MONITOR, LAPTOP, KEYBOARD, PIE, CONSUMABLE, ETC;
+
+    @JsonCreator
+    public static EquipmentType from(String s) { return EquipmentType.valueOf(s.toUpperCase()); }
+}

--- a/src/main/java/Ampersand/GKR/domain/equipment/presentation/dto/request/CreateEquipmentRequest.java
+++ b/src/main/java/Ampersand/GKR/domain/equipment/presentation/dto/request/CreateEquipmentRequest.java
@@ -1,5 +1,6 @@
 package Ampersand.GKR.domain.equipment.presentation.dto.request;
 
+import Ampersand.GKR.domain.equipment.enums.EquipmentType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,4 +14,6 @@ public class CreateEquipmentRequest {
     private String name;
 
     private String description;
+
+    private EquipmentType equipmentType;
 }

--- a/src/main/java/Ampersand/GKR/domain/equipment/presentation/dto/request/EditEquipmentRequest.java
+++ b/src/main/java/Ampersand/GKR/domain/equipment/presentation/dto/request/EditEquipmentRequest.java
@@ -1,5 +1,6 @@
 package Ampersand.GKR.domain.equipment.presentation.dto.request;
 
+import Ampersand.GKR.domain.equipment.enums.EquipmentType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,4 +14,6 @@ public class EditEquipmentRequest {
     private String name;
 
     private String description;
+
+    private EquipmentType equipmentType;
 }

--- a/src/main/java/Ampersand/GKR/domain/equipment/presentation/dto/response/DetailEquipmentResponse.java
+++ b/src/main/java/Ampersand/GKR/domain/equipment/presentation/dto/response/DetailEquipmentResponse.java
@@ -1,5 +1,6 @@
 package Ampersand.GKR.domain.equipment.presentation.dto.response;
 
+import Ampersand.GKR.domain.equipment.enums.EquipmentType;
 import Ampersand.GKR.domain.equipment.enums.RentStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,4 +20,6 @@ public class DetailEquipmentResponse {
     private String description;
 
     private RentStatus rentStatus;
+
+    private EquipmentType equipmentType;
 }

--- a/src/main/java/Ampersand/GKR/domain/equipment/presentation/dto/response/EquipmentResponse.java
+++ b/src/main/java/Ampersand/GKR/domain/equipment/presentation/dto/response/EquipmentResponse.java
@@ -1,6 +1,7 @@
 package Ampersand.GKR.domain.equipment.presentation.dto.response;
 
 import Ampersand.GKR.domain.equipment.entity.Equipment;
+import Ampersand.GKR.domain.equipment.enums.EquipmentType;
 import Ampersand.GKR.domain.equipment.enums.RentStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +22,8 @@ public class EquipmentResponse {
 
     private RentStatus rentStatus;
 
+    private EquipmentType equipmentType;
+
     public static EquipmentResponse toResponse(Equipment equipment) {
 
         return EquipmentResponse.builder()
@@ -29,6 +32,7 @@ public class EquipmentResponse {
                 .imageUrl(equipment.getImageUrl())
                 .description(equipment.getDescription())
                 .rentStatus(equipment.getRentStatus())
+                .equipmentType(equipment.getEquipmentType())
                 .build();
     }
 }

--- a/src/main/java/Ampersand/GKR/domain/equipment/service/CreateEquipmentService.java
+++ b/src/main/java/Ampersand/GKR/domain/equipment/service/CreateEquipmentService.java
@@ -32,6 +32,7 @@ public class CreateEquipmentService {
                 .description(equipmentRequest.getDescription())
                 .imageUrl(fileUrl)
                 .rentStatus(RentStatus.NOT_RENT)
+                .equipmentType(equipmentRequest.getEquipmentType())
                 .build();
 
         equipmentRepository.save(equipment);

--- a/src/main/java/Ampersand/GKR/domain/equipment/service/DetailEquipmentService.java
+++ b/src/main/java/Ampersand/GKR/domain/equipment/service/DetailEquipmentService.java
@@ -22,6 +22,7 @@ public class DetailEquipmentService {
                 .imageUrl(equipment.getImageUrl())
                 .description(equipment.getDescription())
                 .rentStatus(equipment.getRentStatus())
+                .equipmentType(equipment.getEquipmentType())
                 .build();
 
         return detailEquipmentResponse;


### PR DESCRIPTION
- 기자재에 분류 타입 추가 (모니터, 노트북, 키보드, 라즈베리파이, 소모품, 기타)