### PR TITLE
기자재 Order 관련 로직 변경

### DIFF
--- a/src/main/java/Ampersand/GKR/domain/order/entity/Application.java
+++ b/src/main/java/Ampersand/GKR/domain/order/entity/Application.java
@@ -8,6 +8,7 @@ import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -22,8 +23,11 @@ public class Application {
     @Column(name = "order_id")
     private Long id;
 
-    @Column(name = "rental_date")
-    private String rentalDate;
+    @Column(name = "rental_start_date")
+    private LocalDateTime rentalStartDate;
+
+    @Column(name = "rental_end_date")
+    private LocalDateTime rentalEndDate;
 
     @Column(name = "reason")
     private String reason;
@@ -54,8 +58,16 @@ public class Application {
         this.orderStatus = orderStatus;
     }
 
-    public void extensionDate(String rentalDate, String reason) {
-        this.rentalDate = rentalDate;
+    public void setRentalDates() {
+        this.rentalStartDate = LocalDateTime.now();
+        this.rentalEndDate = rentalStartDate.plusMonths(1);
+    }
+
+    public void extensionDate() {
+        this.rentalEndDate = rentalEndDate.plusMonths(1);
+    }
+
+    public void extensionReason(String reason) {
         this.reason = reason;
     }
 }

--- a/src/main/java/Ampersand/GKR/domain/order/presentation/OrderController.java
+++ b/src/main/java/Ampersand/GKR/domain/order/presentation/OrderController.java
@@ -28,9 +28,11 @@ public class OrderController {
 
     private final ListOrderStatusEquipmentService listOrderStatusEquipmentService;
 
-    private final ListNotReturnEquipmentService listNotReturnEquipmentService;
+    private final ListCurrentRentalEquipmentService listCurrentRentalEquipmentService;
 
     private final ListWaitingOrderEquipmentService listWaitingOrderEquipmentService;
+
+    private final ListNotReturnUserEquipmentService listNotReturnUserEquipmentService;
 
 
     @PostMapping("/rental/{id}")
@@ -69,15 +71,21 @@ public class OrderController {
         return new ResponseEntity<>(list, HttpStatus.OK);
     }
 
-    @GetMapping("/noreturn")
+    @GetMapping("/now")
     public ResponseEntity<ListApplicationResponse> notReturnList() {
-        var list = listNotReturnEquipmentService.execute();
+        var list = listCurrentRentalEquipmentService.execute();
         return new ResponseEntity<>(list, HttpStatus.OK);
     }
 
     @GetMapping("/wait")
     public ResponseEntity<ListApplicationResponse> waitingList() {
         var list = listWaitingOrderEquipmentService.execute();
+        return new ResponseEntity<>(list, HttpStatus.OK);
+    }
+
+    @GetMapping("/noreturn")
+    public ResponseEntity<ListApplicationResponse> noReturnList() {
+        var list = listNotReturnUserEquipmentService.execute();
         return new ResponseEntity<>(list, HttpStatus.OK);
     }
 }

--- a/src/main/java/Ampersand/GKR/domain/order/presentation/dto/request/ExtensionEquipmentRequest.java
+++ b/src/main/java/Ampersand/GKR/domain/order/presentation/dto/request/ExtensionEquipmentRequest.java
@@ -10,7 +10,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ExtensionEquipmentRequest {
 
-    private String rentalDate;
-
     private String reason;
 }

--- a/src/main/java/Ampersand/GKR/domain/order/presentation/dto/request/RentalEquipmentRequest.java
+++ b/src/main/java/Ampersand/GKR/domain/order/presentation/dto/request/RentalEquipmentRequest.java
@@ -10,7 +10,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RentalEquipmentRequest {
 
-    private String rentalDate;
-
     private String reason;
 }

--- a/src/main/java/Ampersand/GKR/domain/order/presentation/dto/response/ApplicationResponse.java
+++ b/src/main/java/Ampersand/GKR/domain/order/presentation/dto/response/ApplicationResponse.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -23,6 +25,12 @@ public class ApplicationResponse {
 
     private String userName;
 
+    private String reason;
+
+    private LocalDateTime rentalStartDate;
+
+    private LocalDateTime rentalEndDate;
+
     public static ApplicationResponse toResponse(Application application) {
 
         return ApplicationResponse.builder()
@@ -32,6 +40,9 @@ public class ApplicationResponse {
                 .description(application.getEquipment().getDescription())
                 .orderType(application.getOrderType())
                 .userName(application.getUserName())
+                .reason(application.getReason())
+                .rentalStartDate(application.getRentalStartDate())
+                .rentalEndDate(application.getRentalEndDate())
                 .build();
     }
 }

--- a/src/main/java/Ampersand/GKR/domain/order/repository/ApplicationRepository.java
+++ b/src/main/java/Ampersand/GKR/domain/order/repository/ApplicationRepository.java
@@ -5,6 +5,7 @@ import Ampersand.GKR.domain.order.enums.OrderStatus;
 import Ampersand.GKR.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
@@ -12,4 +13,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     List<Application> findByUserAndOrderStatus(User user, OrderStatus orderStatus);
 
     List<Application> findByOrderStatus(OrderStatus orderStatus);
+
+    List<Application> findByRentalEndDateBefore(LocalDateTime currentDate);
 }

--- a/src/main/java/Ampersand/GKR/domain/order/service/AcceptOrderService.java
+++ b/src/main/java/Ampersand/GKR/domain/order/service/AcceptOrderService.java
@@ -31,10 +31,13 @@ public class AcceptOrderService {
         switch (application.getOrderType()) {
             case RENTAL :
                 application.getEquipment().setEquipmentStatus(EquipmentStatus.RENTING);
+                application.setRentalDates();
                 return;
             case RETURN:
                 application.getEquipment().setEquipmentStatus(EquipmentStatus.NOT_RENT);
                 applicationRepository.delete(application);
+            case EXTENSION:
+                application.extensionDate();
         }
     }
 }

--- a/src/main/java/Ampersand/GKR/domain/order/service/ExtensionEquipmentService.java
+++ b/src/main/java/Ampersand/GKR/domain/order/service/ExtensionEquipmentService.java
@@ -34,7 +34,7 @@ public class ExtensionEquipmentService {
             throw new NotMyRentedEquipmentException();
         }
 
-        application.extensionDate(extensionEquipmentRequest.getRentalDate(), extensionEquipmentRequest.getReason());
+        application.extensionReason(extensionEquipmentRequest.getReason());
 
         application.setOrderInfo(OrderStatus.WAITING, OrderType.EXTENSION);
     }

--- a/src/main/java/Ampersand/GKR/domain/order/service/ListCurrentRentalEquipmentService.java
+++ b/src/main/java/Ampersand/GKR/domain/order/service/ListCurrentRentalEquipmentService.java
@@ -16,7 +16,7 @@ import static Ampersand.GKR.domain.order.presentation.dto.response.ApplicationRe
 
 @ReadOnlyService
 @RequiredArgsConstructor
-public class ListNotReturnEquipmentService {
+public class ListCurrentRentalEquipmentService {
 
     private final ApplicationRepository applicationRepository;
 

--- a/src/main/java/Ampersand/GKR/domain/order/service/ListNotReturnUserEquipmentService.java
+++ b/src/main/java/Ampersand/GKR/domain/order/service/ListNotReturnUserEquipmentService.java
@@ -1,0 +1,41 @@
+package Ampersand.GKR.domain.order.service;
+
+import Ampersand.GKR.domain.order.entity.Application;
+import Ampersand.GKR.domain.order.presentation.dto.response.ListApplicationResponse;
+import Ampersand.GKR.domain.order.repository.ApplicationRepository;
+import Ampersand.GKR.domain.user.entity.User;
+import Ampersand.GKR.global.annotation.ReadOnlyService;
+import Ampersand.GKR.global.util.UserUtil;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static Ampersand.GKR.domain.order.presentation.dto.response.ApplicationResponse.toResponse;
+
+@ReadOnlyService
+@RequiredArgsConstructor
+public class ListNotReturnUserEquipmentService {
+
+    private final ApplicationRepository applicationRepository;
+
+    private final UserUtil userUtil;
+
+    public ListApplicationResponse execute() {
+
+        User user = userUtil.currentUser();
+
+        List<Application> applications = applicationRepository.findByRentalEndDateBefore(LocalDateTime.now());
+
+        ListApplicationResponse listApplicationResponse = ListApplicationResponse.builder()
+                .applicationList(
+                        applications.stream()
+                                .map(application -> toResponse(application))
+                                .collect(Collectors.toList())
+                )
+                .build();
+
+        return listApplicationResponse;
+    }
+}

--- a/src/main/java/Ampersand/GKR/domain/order/service/RentalEquipmentService.java
+++ b/src/main/java/Ampersand/GKR/domain/order/service/RentalEquipmentService.java
@@ -35,7 +35,6 @@ public class RentalEquipmentService {
         }
 
         Application application = Application.builder()
-                .rentalDate(rentalEquipmentRequest.getRentalDate())
                 .reason(rentalEquipmentRequest.getReason())
                 .orderStatus(OrderStatus.WAITING)
                 .orderType(OrderType.RENTAL)

--- a/src/main/java/Ampersand/GKR/global/security/config/SecurityConfig.java
+++ b/src/main/java/Ampersand/GKR/global/security/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                 .antMatchers(HttpMethod.POST, "/order/extension/{id}").authenticated()
                 .antMatchers(HttpMethod.GET, "/order/state").authenticated()
 
+                .antMatchers(HttpMethod.GET, "/order/now").hasAnyAuthority("ROLE_ADMIN")
                 .antMatchers(HttpMethod.GET, "/order/noreturn").hasAnyAuthority("ROLE_ADMIN")
                 .antMatchers(HttpMethod.GET, "/order/wait").hasAnyAuthority("ROLE_ADMIN")
                 .antMatchers(HttpMethod.PATCH, "/order/reject/{id}").hasAnyAuthority("ROLE_ADMIN")


### PR DESCRIPTION
- 기자재를 대여할 시 사용자가 임의로 작성했던 대여 만료 일자를 LocalDateTime을 사용해 대여를 처음 시작한 시간과 대여 만료일이 자동으로 설정되도록 변경

- 기자재 신청 승인 서비스에 연장 승인에 대한 로직 추가

- 사용자가 대여중인 기자재와 반납 기간이 지난 기자재의 api 분리
